### PR TITLE
Feature/extract user details auth

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,0 @@
-.git
-src
-pom.xml
-README.adoc
-.editorconfig
-
-target/*.jar.original
-target/*javadoc.jar
-target/*sources.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM smartcosmos/service
-MAINTAINER SMART COSMOS Platform Core Team
-
-ADD target/smartcosmos-*.jar  /opt/smartcosmos/smartcosmos-edge-user-devkit.jar
-
-CMD ["/opt/smartcosmos/smartcosmos-edge-user-devkit.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -20,27 +20,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
             <version>3.1.4</version>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mariadb.jdbc</groupId>
-            <artifactId>mariadb-java-client</artifactId>
-        </dependency>
-        <dependency>
             <groupId>net.smartcosmos</groupId>
             <artifactId>smartcosmos-framework</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,73 +37,9 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-oauth2</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.querydsl</groupId>
-            <artifactId>querydsl-apt</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path-assert</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct</artifactId>
-            <version>1.0.0.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.smartcosmos</groupId>
-            <artifactId>smartcosmos-framework-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.jayway.restassured</groupId>
-            <artifactId>spring-mock-mvc</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,7 @@
     267 Cane Creek Rd, Fletcher, NC, 28732, USA
     All Rights Reserved.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>net.smartcosmos</groupId>
@@ -124,8 +123,7 @@
 
     <scm>
         <connection>scm:git:git://github.com/SMARTRACTECHNOLOGY/smartcosmos-user-entity-devkit.git</connection>
-        <developerConnection>scm:git@github.com:SMARTRACTECHNOLOGY/smartcosmos-user-entity-devkit.git
-        </developerConnection>
+        <developerConnection>scm:git@github.com:SMARTRACTECHNOLOGY/smartcosmos-user-entity-devkit.git</developerConnection>
         <url>https://github.com/SMARTRACTECHNOLOGY/smartcosmos-user-entity-devkit/tree/master/</url>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    SMART COSMOS User Details Devkit Entities
+    Copyright (C) 2016 SMARTRAC TECHNOLOGY Fletcher, Inc.
+    267 Cane Creek Rd, Fletcher, NC, 28732, USA
+    All Rights Reserved.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>net.smartcosmos</groupId>
+        <artifactId>smartcosmos-framework-parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+        <relativePath></relativePath>
+    </parent>
+    <artifactId>smartcosmos-user-entity-devkit</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+    <name>SMART COSMOS USER DAO Entities and Services</name>
+    <description>Devkit implementation of User mananagement entities and data layer</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.uuid</groupId>
+            <artifactId>java-uuid-generator</artifactId>
+            <version>3.1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework</artifactId>
+            <version>3.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-oauth2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path-assert</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.0.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>spring-mock-mvc</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <scm>
+        <connection>scm:git:git://github.com/SMARTRACTECHNOLOGY/smartcosmos-user-entity-devkit.git</connection>
+        <developerConnection>scm:git@github.com:SMARTRACTECHNOLOGY/smartcosmos-user-entity-devkit.git
+        </developerConnection>
+        <url>https://github.com/SMARTRACTECHNOLOGY/smartcosmos-user-entity-devkit/tree/master/</url>
+    </scm>
+
+</project>

--- a/src/main/java/net/smartcosmos/cluster/userdetails/converter/PasswordEncodingConverter.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/converter/PasswordEncodingConverter.java
@@ -1,0 +1,31 @@
+package net.smartcosmos.cluster.userdetails.converter;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+@Converter
+public class PasswordEncodingConverter implements AttributeConverter<String, String> {
+
+    private static PasswordEncoder passwordEncoder;
+
+    @Override
+    public String convertToDatabaseColumn(String rawPassword) {
+        return (StringUtils.isNotBlank(rawPassword) ? passwordEncoder.encode(rawPassword) : rawPassword);
+    }
+
+    @Override
+    public String convertToEntityAttribute(String encodedPassword) {
+        return encodedPassword;
+    }
+
+    @Autowired
+    public void setPasswordEncoder(PasswordEncoder passwordEncoder) {
+        PasswordEncodingConverter.passwordEncoder = passwordEncoder;
+    }
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/domain/AuthorityEntity.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/domain/AuthorityEntity.java
@@ -1,0 +1,49 @@
+package net.smartcosmos.cluster.userdetails.domain;
+
+import java.beans.ConstructorProperties;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import javax.validation.constraints.Size;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Initially created by SMART COSMOS Team on July 06, 2016.
+ */
+@Entity(name = "authority")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Data
+@Table(name = "authority", uniqueConstraints = @UniqueConstraint(columnNames = { "authority" }))
+@EntityListeners({ AuditingEntityListener.class })
+
+public class AuthorityEntity {
+
+    private static final int STRING_FIELD_LENGTH = 255;
+
+    @Id
+    @Size(max = STRING_FIELD_LENGTH)
+    @Column(name = "authority", length = STRING_FIELD_LENGTH, nullable = false, updatable = false)
+    private String authority;
+
+    /*
+Lombok's @Builder is not able to deal with field initialization default values. That's a known issue which won't get fixed:
+https://github.com/rzwitserloot/lombok/issues/663
+
+We therefore provide our own AllArgsConstructor that is used by the generated builder and takes care of field initialization.
+*/
+    @Builder
+    @ConstructorProperties({ "authority" })
+    protected AuthorityEntity(
+        String authority) {
+        this.authority = authority;
+    }
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/domain/RoleEntity.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/domain/RoleEntity.java
@@ -1,0 +1,128 @@
+package net.smartcosmos.cluster.userdetails.domain;
+
+import java.beans.ConstructorProperties;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.UniqueConstraint;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Initially created by SMART COSMOS Team on July 06, 2016.
+ */
+@Entity(name = "role")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Data
+@Table(name = "role", uniqueConstraints = @UniqueConstraint(columnNames = { "name", "tenantId" }))
+@EntityListeners({ AuditingEntityListener.class })
+
+public class RoleEntity {
+
+    private static final int UUID_LENGTH = 16;
+    private static final int STRING_FIELD_LENGTH = 255;
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Type(type = "uuid-binary")
+    @Column(name = "id", length = UUID_LENGTH)
+    private UUID id;
+
+    @NotNull
+    @Type(type = "uuid-binary")
+    @Column(name = "tenantId", length = UUID_LENGTH, nullable = false, updatable = false)
+    private UUID tenantId;
+
+    @NotEmpty
+    @Size(max = STRING_FIELD_LENGTH)
+    @Column(name = "name", length = STRING_FIELD_LENGTH, nullable = false, updatable = false)
+    private String name;
+
+    @Size(max = STRING_FIELD_LENGTH)
+    @Column(name = "description", length = STRING_FIELD_LENGTH, nullable = true, updatable = true)
+    private String description;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+    private Set<UserEntity> users;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+    @JoinTable(name = "role_authorities",
+               joinColumns = { @JoinColumn(name = "role") },
+               inverseJoinColumns = { @JoinColumn(name = "authority") })
+    private Set<AuthorityEntity> authorities;
+
+    @CreatedDate
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created", insertable = true, updatable = false)
+    private Date created;
+
+    @LastModifiedDate
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "lastModified", nullable = false, insertable = true, updatable = true)
+    private Date lastModified;
+
+    @Basic
+    @NotNull
+    @Column(name = "active", nullable = false)
+    private Boolean active;
+
+    /*
+    Lombok's @Builder is not able to deal with field initialization default values. That's a known issue which won't get fixed:
+    https://github.com/rzwitserloot/lombok/issues/663
+
+    We therefore provide our own AllArgsConstructor that is used by the generated builder and takes care of field initialization.
+ */
+    @Builder
+    @ConstructorProperties({ "id", "tenantId", "name", "description", "users", "authorities", "active" })
+    protected RoleEntity(
+        UUID id,
+        UUID tenantId,
+        String name,
+        String description,
+        Set<UserEntity> users,
+        Set<AuthorityEntity> authorities,
+        Boolean active) {
+        this.id = id;
+        this.tenantId = tenantId;
+        this.name = name;
+        this.description = description;
+        this.users = new HashSet<>();
+        if (users != null && !users.isEmpty()) {
+            this.users.addAll(users);
+        }
+        this.authorities = new HashSet<>();
+        if (authorities != null && !authorities.isEmpty()) {
+            this.authorities.addAll(authorities);
+        }
+        this.active = active != null ? active : true;
+    }
+
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/domain/UserEntity.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/domain/UserEntity.java
@@ -1,0 +1,152 @@
+package net.smartcosmos.cluster.userdetails.domain;
+
+import java.beans.ConstructorProperties;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Set;
+import java.util.UUID;
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.UniqueConstraint;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import net.smartcosmos.cluster.userdetails.converter.PasswordEncodingConverter;
+
+@Entity(name = "user")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Data
+@Table(name = "user", uniqueConstraints = @UniqueConstraint(columnNames = { "username" }))
+// this will be the future, but currently isn't supported:
+//@Table(name = "user", uniqueConstraints = @UniqueConstraint(columnNames = { "username", "tenantId" }))
+@EntityListeners({ AuditingEntityListener.class })
+public class UserEntity implements Serializable {
+
+    private static final int UUID_LENGTH = 16;
+    private static final int STRING_FIELD_LENGTH = 255;
+    private static final int BIG_STRING_FIELD_LENGTH = 767;
+
+    /*
+        Without setting an appropriate Hibernate naming strategy, the column names specified in the @Column annotations below will be converted
+        from camel case to underscore, e.g.: systemUuid -> system_uuid
+
+        To avoid that, select the "old" naming strategy org.hibernate.cfg.EJB3NamingStrategy in your configuration (smartcosmos-ext-objects-rdao.yml):
+        jpa.hibernate.naming_strategy: org.hibernate.cfg.EJB3NamingStrategy
+     */
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Type(type = "uuid-binary")
+    @Column(name = "id", length = UUID_LENGTH)
+    private UUID id;
+
+    @NotNull
+    @Type(type = "uuid-binary")
+    @Column(name = "tenantId", length = UUID_LENGTH, nullable = false, updatable = false)
+    private UUID tenantId;
+
+    @NotEmpty
+    @Size(max = STRING_FIELD_LENGTH)
+    @Column(name = "username", length = STRING_FIELD_LENGTH, nullable = false, updatable = true)
+    private String username;
+
+    @Size(max = STRING_FIELD_LENGTH)
+    @Column(name = "emailAddress", length = STRING_FIELD_LENGTH, nullable = true, updatable = true)
+    private String emailAddress;
+
+    @Size(max = STRING_FIELD_LENGTH)
+    @Column(name = "givenName", length = STRING_FIELD_LENGTH, nullable = true, updatable = true)
+    private String givenName;
+
+    @Size(max = STRING_FIELD_LENGTH)
+    @Column(name = "surname", length = STRING_FIELD_LENGTH, nullable = true, updatable = true)
+    private String surname;
+
+    @NotEmpty
+    @Size(max = STRING_FIELD_LENGTH)
+    @Column(name = "password", length = STRING_FIELD_LENGTH, nullable = false, updatable = true)
+    @Convert(converter = PasswordEncodingConverter.class)
+    private String password;
+
+    @ManyToMany(fetch = FetchType.EAGER, cascade = { CascadeType.PERSIST, CascadeType.MERGE })
+    @JoinTable(name = "user_roles",
+               joinColumns = { @JoinColumn(name = "user") },
+               inverseJoinColumns = { @JoinColumn(name = "role") })
+    private Set<RoleEntity> roles;
+
+    @CreatedDate
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "created", insertable = true, updatable = false)
+    private Date created;
+
+    @LastModifiedDate
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "lastModified", nullable = false, insertable = true, updatable = true)
+    private Date lastModified;
+
+    @Basic
+    @NotNull
+    @Column(name = "active", nullable = false)
+    private Boolean active;
+
+    /*
+        Lombok's @Builder is not able to deal with field initialization default values. That's a known issue which won't get fixed:
+        https://github.com/rzwitserloot/lombok/issues/663
+
+        We therefore provide our own AllArgsConstructor that is used by the generated builder and takes care of field initialization.
+     */
+    @Builder
+    @ConstructorProperties({ "id", "tenantId", "username", "emailAddress", "givenName", "surname", "password", "roles",
+                             "created", "lastModified", "active" })
+    protected UserEntity(
+        UUID id,
+        UUID tenantId,
+        String username,
+        String emailAddress,
+        String givenName,
+        String surname,
+        String password,
+        Set<RoleEntity> roles,
+        Date created,
+        Date lastModified,
+        Boolean active) {
+
+        this.id = id;
+        this.tenantId = tenantId;
+        this.username = username;
+        this.emailAddress = emailAddress;
+        this.givenName = givenName;
+        this.surname = surname;
+        this.password = password;
+        this.roles = roles;
+        this.created = created;
+        this.lastModified = lastModified;
+        this.active = active != null ? active : true;
+    }
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/repository/RoleRepository.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/repository/RoleRepository.java
@@ -1,0 +1,29 @@
+package net.smartcosmos.cluster.userdetails.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.PagingAndSortingRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.smartcosmos.cluster.userdetails.domain.RoleEntity;
+
+/**
+ * Initially created by SMART COSMOS Team on June 30, 2016.
+ */
+public interface RoleRepository extends JpaRepository<RoleEntity, String>,
+                                        PagingAndSortingRepository<RoleEntity, String>,
+                                        JpaSpecificationExecutor<RoleEntity> {
+
+    Optional<RoleEntity> findByTenantIdAndNameIgnoreCase(UUID tenantId, String name);
+
+    Optional<RoleEntity> findByTenantIdAndId(UUID tenantId, UUID id);
+
+    @Transactional
+    List<RoleEntity> deleteByTenantIdAndId(UUID tenantId, UUID id);
+
+    List<RoleEntity> findByTenantId(UUID tenantId);
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/repository/UserRepository.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/repository/UserRepository.java
@@ -1,0 +1,29 @@
+package net.smartcosmos.cluster.userdetails.repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+import net.smartcosmos.cluster.userdetails.domain.UserEntity;
+
+/**
+ * Initially created by SMART COSMOS Team on June 30, 2016.
+ */
+public interface UserRepository extends JpaRepository<UserEntity, UUID>,
+                                        PagingAndSortingRepository<UserEntity, UUID>,
+                                        JpaSpecificationExecutor<UserEntity>,
+                                        UserRepositoryCustom {
+
+    Optional<UserEntity> findByUsernameAndTenantId(String username, UUID tenantId);
+
+    Optional<UserEntity> findByTenantIdAndId(UUID tenantId, UUID id);
+
+    List<UserEntity> findByTenantId(UUID tenantId);
+
+    Optional<UserEntity> findByUsernameIgnoreCase(String username);
+
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/repository/UserRepositoryCustom.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/repository/UserRepositoryCustom.java
@@ -1,0 +1,59 @@
+package net.smartcosmos.cluster.userdetails.repository;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.validation.ConstraintViolationException;
+
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.annotation.Transactional;
+
+import net.smartcosmos.cluster.userdetails.domain.AuthorityEntity;
+import net.smartcosmos.cluster.userdetails.domain.UserEntity;
+
+public interface UserRepositoryCustom {
+
+    /**
+     * Saves a user entity in a {@link UserRepository}.
+     *
+     * @param entity the user entity to persist
+     * @return the persisted user entity
+     * @throws ConstraintViolationException if the transaction fails due to violated constraints
+     * @throws TransactionException         if the transaction fails because of something else
+     */
+    UserEntity persist(UserEntity entity) throws ConstraintViolationException, TransactionException;
+
+    /**
+     * Gets a user entity that matches the given username/password credentials.
+     *
+     * @param username the username
+     * @param password the password
+     * @return an Optional with the user entity or an empty optional if the credentials didn't match any user
+     * @throws IllegalArgumentException in case {@code username} or {@code password} were {@code null}
+     */
+    @Transactional
+    Optional<UserEntity> getUserByCredentials(String username, String password) throws IllegalArgumentException;
+
+    /**
+     * Gets the authority set for a given user.
+     *
+     * @param tenantId the tenant ID
+     * @param userId the user ID
+     * @return an Optional with the set of all authorities retrieved from the associated roles or an empty optional if the user doesn't exist
+     */
+    @Transactional
+    Optional<Set<AuthorityEntity>> getAuthorities(UUID tenantId, UUID userId);
+
+    /**
+     * Assigns a set of roles to a given user.
+     *
+     * @param tenantId the tenant ID
+     * @param id the user ID
+     * @param roleNames the names of roles to assign to the user
+     * @return an Optional with the updated user entity or an empty optional if the user doesn't exist
+     * @throws IllegalArgumentException if any of the given role names doesn't exist
+     */
+    @Transactional
+    Optional<UserEntity> addRolesToUser(UUID tenantId, UUID id, Collection<String> roleNames) throws IllegalArgumentException;
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/repository/UserRepositoryImpl.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/repository/UserRepositoryImpl.java
@@ -1,0 +1,134 @@
+package net.smartcosmos.cluster.userdetails.repository;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import javax.validation.ConstraintViolationException;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.hibernate.Hibernate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.TransactionException;
+import org.springframework.util.Assert;
+
+import net.smartcosmos.cluster.userdetails.domain.AuthorityEntity;
+import net.smartcosmos.cluster.userdetails.domain.RoleEntity;
+import net.smartcosmos.cluster.userdetails.domain.UserEntity;
+
+import static java.util.stream.Collectors.toSet;
+
+@Component
+public class UserRepositoryImpl implements UserRepositoryCustom {
+
+    @Lazy
+    private final UserRepository userRepository;
+
+    @Lazy
+    private final RoleRepository roleRepository;
+
+    private final PasswordEncoder passwordEncoder;
+
+    @Lazy
+    @Autowired
+    public UserRepositoryImpl(UserRepository userRepository, RoleRepository roleRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public UserEntity persist(UserEntity entity) throws ConstraintViolationException, TransactionException {
+        try {
+            return userRepository.save(entity);
+        } catch (TransactionException e) {
+            // we expect constraint violations to be the root cause for exceptions here,
+            // so we throw this particular exception back to the caller
+            if (ExceptionUtils.getRootCause(e) instanceof ConstraintViolationException) {
+                throw (ConstraintViolationException) ExceptionUtils.getRootCause(e);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public Optional<UserEntity> getUserByCredentials(String username, String password) throws IllegalArgumentException {
+
+        Assert.notNull(username, "username must not be null");
+        Assert.notNull(password, "password must not be null");
+
+        Optional<UserEntity> userOptional = userRepository.findByUsernameIgnoreCase(username);
+
+        if (userOptional.isPresent() && passwordEncoder.matches(password, userOptional.get().getPassword())) {
+            return userOptional;
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Set<AuthorityEntity>> getAuthorities(UUID tenantId, UUID userId) {
+
+        Optional<UserEntity> userOptional = userRepository.findByTenantIdAndId(tenantId, userId);
+        if (userOptional.isPresent()) {
+            Set<AuthorityEntity> authorities = new LinkedHashSet<>();
+
+            UserEntity user = userOptional.get();
+            user.getRoles().stream()
+                .filter(RoleEntity::getActive)
+                .forEach(role -> authorities.addAll(role.getAuthorities()));
+
+            return Optional.of(authorities);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<UserEntity> addRolesToUser(UUID tenantId, UUID userId, Collection<String> roleNames) throws IllegalArgumentException {
+
+        Optional<UserEntity> userOptional = userRepository.findByTenantIdAndId(tenantId, userId);
+        if (userOptional.isPresent()) {
+            UserEntity user = userOptional.get();
+
+            Set<RoleEntity> roleSet = initRoleEntities(user);
+            Set<RoleEntity> newRoleSet = getRoleEntities(tenantId, roleNames);
+            roleSet.addAll(newRoleSet);
+
+            return Optional.of(user);
+        }
+
+        return Optional.empty();
+    }
+
+    private Set<RoleEntity> getRoleEntities(UUID tenantId, Collection<String> roleNames) {
+
+        return roleNames
+            .stream()
+            .map(roleName -> {
+                Optional<RoleEntity> role = roleRepository.findByTenantIdAndNameIgnoreCase(tenantId, roleName);
+                if (role.isPresent()) {
+                    return role.get();
+                } else {
+                    String msg = String.format("Role '%s' does not exist", roleName);
+                    throw new IllegalArgumentException(msg);
+                }
+            })
+            .collect(toSet());
+    }
+
+    private Set<RoleEntity> initRoleEntities(UserEntity user) {
+        Set<RoleEntity> roleEntities = user.getRoles();
+
+        if (!Hibernate.isInitialized(roleEntities)) {
+            Hibernate.initialize(roleEntities);
+        }
+
+        return roleEntities;
+    }
+}

--- a/src/main/java/net/smartcosmos/cluster/userdetails/util/UuidUtil.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/util/UuidUtil.java
@@ -1,0 +1,77 @@
+package net.smartcosmos.cluster.userdetails.util;
+
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.uuid.Generators;
+
+public class UuidUtil {
+
+    private static final String URN_PREFIX = "urn";
+    private static final String URN_SEPARATOR = ":";
+
+    private static final String UUID_TYPE = "uuid";
+
+    private static final String TENANT_PREFIX = "tenant";
+    private static final String USER_PREFIX = "user";
+    private static final String THING_PREFIX = "thing";
+    private static final String ROLE_PREFIX = "role";
+
+    public static UUID getUuidFromUrn(String urn) throws IllegalArgumentException {
+
+        String urnScheme = "urn:.*:uuid:([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})";
+
+        Pattern p = Pattern.compile(urnScheme, Pattern.CASE_INSENSITIVE);
+        Matcher m = p.matcher(urn);
+        if (m.find()) {
+            return UUID.fromString(m.group(1));
+        }
+
+        throw new IllegalArgumentException(
+            String.format("Provided URN '%s' does not match the required URN scheme '%s'", urn, "urn:{prefix}:uuid:{uuid}"));
+    }
+
+    public static String getThingUrnFromUuid(UUID uuid) {
+        return getPrefixUrnFromUuid(THING_PREFIX, uuid);
+    }
+
+    public static String getTenantUrnFromUuid(UUID uuid) {
+        return getPrefixUrnFromUuid(TENANT_PREFIX, uuid);
+    }
+
+    public static String getUserUrnFromUuid(UUID uuid) {
+        return getPrefixUrnFromUuid(USER_PREFIX, uuid);
+    }
+
+    public static String getRoleUrnFromUuid(UUID uuid) {
+        return getPrefixUrnFromUuid(ROLE_PREFIX, uuid);
+    }
+
+    static String getPrefixUrnFromUuid(String prefix, UUID uuid) {
+        return new StringBuilder(URN_PREFIX)
+            .append(URN_SEPARATOR)
+            .append(prefix)
+            .append(URN_SEPARATOR)
+            .append(UUID_TYPE)
+            .append(URN_SEPARATOR)
+            .append(uuid.toString())
+            .toString()
+            .toLowerCase();
+    }
+
+    public static UUID getNewUuid() {
+
+        String baseUuidString = Generators.timeBasedGenerator().generate().toString();
+        String[] parts = baseUuidString.split("-");
+
+        String sortedUuidString = new StringBuilder(36)
+            .append(parts[2]).append(parts[1]).append("-")
+            .append(parts[0].substring(0, 4)).append("-")
+            .append(parts[0].substring(4, 8)).append("-")
+            .append(parts[3]).append("-")
+            .append(parts[4]).toString();
+
+        return UUID.fromString(sortedUuidString);
+    }
+}

--- a/src/test/java/net/smartcosmos/cluster/userdetails/domain/UserEntityTest.java
+++ b/src/test/java/net/smartcosmos/cluster/userdetails/domain/UserEntityTest.java
@@ -1,0 +1,60 @@
+package net.smartcosmos.cluster.userdetails.domain;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+import org.junit.*;
+
+import net.smartcosmos.cluster.userdetails.rest.resrouce.UserPersistenceTestApplication;
+import net.smartcosmos.util.UuidUtil;
+
+import static org.junit.Assert.*;
+
+@org.springframework.boot.test.SpringApplicationConfiguration(classes = { UserPersistenceTestApplication.class })
+@SuppressWarnings("Duplicates")
+public class UserEntityTest {
+
+    private static Validator validator;
+
+    private static java.util.List<String> adminRole = new java.util.ArrayList<>();
+    private static java.util.List<String> userRole = new java.util.ArrayList<>();
+    private static java.util.List<String> twoRoles = new java.util.ArrayList<>();
+
+    @BeforeClass
+    public static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+
+        adminRole.add("Admin");
+        userRole.add("User");
+        twoRoles.add("Admin");
+        twoRoles.add("User");
+    }
+
+    @Test
+    public void thatEverythingIsOk() {
+
+        RoleEntity adminRole = RoleEntity.builder().name("Admin").build();
+        Set<RoleEntity> roleEntities = new HashSet<>();
+        roleEntities.add(adminRole);
+
+        UserEntity userEntity = UserEntity.builder()
+            .tenantId(UuidUtil.getNewUuid())
+            .username("some name")
+            .emailAddress("timc@example.com")
+            .givenName("Tim")
+            .surname("Cross")
+            .password("PleaseChangeMeImmediately")
+            .roles(roleEntities)
+            .build();
+
+        Set<ConstraintViolation<UserEntity>> violationSet = validator.validate(userEntity);
+
+        assertTrue(violationSet.isEmpty());
+    }
+
+}

--- a/src/test/java/net/smartcosmos/cluster/userdetails/rest/resrouce/UserPersistenceTestApplication.java
+++ b/src/test/java/net/smartcosmos/cluster/userdetails/rest/resrouce/UserPersistenceTestApplication.java
@@ -1,0 +1,12 @@
+package net.smartcosmos.cluster.userdetails.rest.resrouce;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Test config.
+ */
+@EnableAutoConfiguration
+@Configuration
+public class UserPersistenceTestApplication {
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Moves out the database-specific classes to their own library to be shared by the user \* services in the DevKit that need to have access to a common datastore.
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests, and in Postman (for User Details DevKit).
#### Depends On

Nothing, but is required for User DevKit and User Details DevKit.
