### PR TITLE
RoleEntity.java had updatable set to false for role names

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,13 @@
+= SMART COSMOS DevKit User Details Service Release Notes
+
+== UNRELEASED
+
+=== New Features
+
+=== Bugfixes & Improvements
+
+* OBJECTS-1153 Updates to Roles were not updating Role name.
+
+== Release 3.0.0 (August 12, 2016)
+
+Initial release.

--- a/src/main/java/net/smartcosmos/cluster/userdetails/domain/RoleEntity.java
+++ b/src/main/java/net/smartcosmos/cluster/userdetails/domain/RoleEntity.java
@@ -63,7 +63,7 @@ public class RoleEntity {
 
     @NotEmpty
     @Size(max = STRING_FIELD_LENGTH)
-    @Column(name = "name", length = STRING_FIELD_LENGTH, nullable = false, updatable = false)
+    @Column(name = "name", length = STRING_FIELD_LENGTH, nullable = false, updatable = true)
     private String name;
 
     @Size(max = STRING_FIELD_LENGTH)


### PR DESCRIPTION
### What changes were proposed in this pull request?

@Column annotation on Role name changed to updatable = true, as per API documentation.

### How is this patch documented?

one annotation parameter changed from false to true.

### How was this patch tested?

Unit tests in smartcosmos-edge-user-devkit: successful update test now tests name updates,
and there is an additional test to verify that update fails when another Role already has the
incoming name.

#### Depends On

Nothing.
